### PR TITLE
homework 7

### DIFF
--- a/kubernetes-operators/clusterrole.yaml
+++ b/kubernetes-operators/clusterrole.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: mysql-operator
+rules:
+  - apiGroups: ["otus.homework"]
+    resources: ["mysqls"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: [""]
+    resources: ["services"]
+    verbs: ["get", "list", "watch", “create", "update", "patch", "delete"]
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "create", "delete"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch", "create", "delete"]

--- a/kubernetes-operators/crbinding.yaml
+++ b/kubernetes-operators/crbinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: mysql-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: mysql-operator
+subjects:
+  - kind: ServiceAccount
+    name: mysql-operator
+    namespace: operators

--- a/kubernetes-operators/crd.yaml
+++ b/kubernetes-operators/crd.yaml
@@ -1,0 +1,37 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: mysqls.otus.homework
+spec:
+  group: otus.homework
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                image:
+                  type: string
+                database:
+                  type: string
+                password:
+                  type: string
+                storage_size:
+                  type: string
+              required:
+                - image
+                - database
+                - password
+                - storage_size
+  scope: Namespaced
+  names:
+    plural: mysqls
+    singular: mysql
+    kind: MySQL
+    shortNames:
+      - mysql

--- a/kubernetes-operators/deploy.yaml
+++ b/kubernetes-operators/deploy.yaml
@@ -1,0 +1,29 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mysql-operator
+  namespace: operators
+  labels:
+    app: mysql-operator
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: mysql-operator
+  template:
+    metadata:
+      labels:
+        app: mysql-operator
+    spec:
+      serviceAccountName: mysql-operator
+      containers:
+        - name: mysql-operator
+          image: roflmaoinmysoul/mysql-operator:1.0.0
+          imagePullPolicy: IfNotPresent
+          resources:
+            limits:
+              cpu: "1"
+              memory: 512Mi
+            requests:
+              cpu: "0.2"
+              memory: 256Mi

--- a/kubernetes-operators/mysql.yaml
+++ b/kubernetes-operators/mysql.yaml
@@ -1,0 +1,10 @@
+apiVersion: otus.homework/v1
+kind: MySQL
+metadata:
+  name: my-mysql
+  namespace: operators
+spec:
+  image: "mysql:latest"
+  database: "mydb"
+  password: "mypass123"
+  storage_size: "1Gi"

--- a/kubernetes-operators/mysqloperator.py
+++ b/kubernetes-operators/mysqloperator.py
@@ -1,0 +1,298 @@
+import kopf
+import kubernetes.client
+from kubernetes.client.rest import ApiException
+import yaml
+import logging
+
+# Настройка логирования
+logging.basicConfig(level=logging.INFO)
+
+@kopf.on.create('otus.homework', 'v1', 'mysqls')
+def create_mysql_instance(spec, name, namespace, logger, **kwargs):
+    """Создание всех ресурсов для MySQL инстанса"""
+    
+    # Параметры из CRD
+    image = spec.get('image', 'mysql:8.0')
+    database = spec.get('database', 'defaultdb')
+    password = spec.get('password', '')
+    storage_size = spec.get('storage_size', '10Gi')
+    
+    logger.info(f"Создание MySQL инстанса {name} в namespace {namespace}")
+    logger.info(f"Параметры: image={image}, database={database}, storage={storage_size}")
+    
+    # Создание PersistentVolume
+    pv_manifest = create_pv_manifest(name, storage_size)
+    kopf.adopt(pv_manifest)
+    
+    # Создание PersistentVolumeClaim
+    pvc_manifest = create_pvc_manifest(name, namespace, storage_size)
+    kopf.adopt(pvc_manifest)
+    
+    # Создание Service
+    service_manifest = create_service_manifest(name, namespace)
+    kopf.adopt(service_manifest)
+    
+    # Создание Deployment
+    deployment_manifest = create_deployment_manifest(
+        name, namespace, image, database, password, storage_size
+    )
+    kopf.adopt(deployment_manifest)
+    
+    # Применение манифестов
+    api = kubernetes.client.CoreV1Api()
+    apps_api = kubernetes.client.AppsV1Api()
+    
+    try:
+        # Создаем PersistentVolume
+        api.create_persistent_volume(body=pv_manifest)
+        logger.info(f"PersistentVolume {name} создан")
+        
+        # Создаем PersistentVolumeClaim
+        api.create_namespaced_persistent_volume_claim(
+            namespace=namespace, body=pvc_manifest
+        )
+        logger.info(f"PersistentVolumeClaim {name} создан")
+        
+        # Создаем Service
+        api.create_namespaced_service(namespace=namespace, body=service_manifest)
+        logger.info(f"Service {name} создан")
+        
+        # Создаем Deployment
+        apps_api.create_namespaced_deployment(
+            namespace=namespace, body=deployment_manifest
+        )
+        logger.info(f"Deployment {name} создан")
+        
+    except ApiException as e:
+        logger.error(f"Ошибка при создании ресурсов: {e}")
+        raise kopf.TemporaryError(f"Ошибка создания ресурсов: {e}", delay=30)
+
+@kopf.on.delete('otus.homework', 'v1', 'mysqls')
+def delete_mysql_instance(name, namespace, logger, **kwargs):
+    """Удаление всех ресурсов при удалении MySQL инстанса"""
+    
+    logger.info(f"Удаление MySQL инстанса {name} из namespace {namespace}")
+    
+    api = kubernetes.client.CoreV1Api()
+    apps_api = kubernetes.client.AppsV1Api()
+    
+    try:
+        # Удаляем Deployment
+        apps_api.delete_namespaced_deployment(
+            name=f"mysql-{name}",
+            namespace=namespace
+        )
+        logger.info(f"Deployment mysql-{name} удален")
+        
+        # Удаляем Service
+        api.delete_namespaced_service(
+            name=f"mysql-{name}",
+            namespace=namespace
+        )
+        logger.info(f"Service mysql-{name} удален")
+        
+        # Удаляем PVC
+        api.delete_namespaced_persistent_volume_claim(
+            name=f"mysql-{name}-pvc",
+            namespace=namespace
+        )
+        logger.info(f"PVC mysql-{name}-pvc удален")
+        
+        # Удаляем PV
+        api.delete_persistent_volume(name=f"mysql-{name}-pv")
+        logger.info(f"PV mysql-{name}-pv удален")
+        
+    except ApiException as e:
+        if e.status != 404:  # Игнорируем ошибки "не найден"
+            logger.error(f"Ошибка при удалении ресурсов: {e}")
+            raise kopf.TemporaryError(f"Ошибка удаления ресурсов: {e}", delay=30)
+
+@kopf.on.field('otus.homework', 'v1', 'mysqls', field='spec.image')
+def update_mysql_image(spec, old, new, name, namespace, logger, **kwargs):
+    """Обработка изменения образа MySQL"""
+    if old != new:
+        logger.info(f"Обновление образа MySQL для {name}: {old} -> {new}")
+        update_deployment_image(name, namespace, new, logger)
+
+def create_pv_manifest(name, storage_size):
+    """Создание манифеста для PersistentVolume"""
+    return {
+        'apiVersion': 'v1',
+        'kind': 'PersistentVolume',
+        'metadata': {
+            'name': f'mysql-{name}-pv',
+            'labels': {
+                'app': 'mysql',
+                'instance': name,
+                'created-by': 'mysql-operator'
+            }
+        },
+        'spec': {
+            'capacity': {'storage': storage_size},
+            'accessModes': ['ReadWriteOnce'],
+            'persistentVolumeReclaimPolicy': 'Retain',
+            'storageClassName': 'manual',
+            'hostPath': {
+                'path': f'/data/mysql-{name}'
+            }
+        }
+    }
+
+def create_pvc_manifest(name, namespace, storage_size):
+    """Создание манифеста для PersistentVolumeClaim"""
+    return {
+        'apiVersion': 'v1',
+        'kind': 'PersistentVolumeClaim',
+        'metadata': {
+            'name': f'mysql-{name}-pvc',
+            'namespace': namespace,
+            'labels': {
+                'app': 'mysql',
+                'instance': name,
+                'created-by': 'mysql-operator'
+            }
+        },
+        'spec': {
+            'storageClassName': 'manual',
+            'accessModes': ['ReadWriteOnce'],
+            'resources': {
+                'requests': {'storage': storage_size}
+            },
+            'volumeName': f'mysql-{name}-pv'
+        }
+    }
+
+def create_service_manifest(name, namespace):
+    """Создание манифеста для Service"""
+    return {
+        'apiVersion': 'v1',
+        'kind': 'Service',
+        'metadata': {
+            'name': f'mysql-{name}',
+            'namespace': namespace,
+            'labels': {
+                'app': 'mysql',
+                'instance': name,
+                'created-by': 'mysql-operator'
+            }
+        },
+        'spec': {
+            'type': 'ClusterIP',
+            'ports': [
+                {
+                    'port': 3306,
+                    'targetPort': 3306,
+                    'name': 'mysql'
+                }
+            ],
+            'selector': {
+                'app': 'mysql',
+                'instance': name
+            }
+        }
+    }
+
+def create_deployment_manifest(name, namespace, image, database, password, storage_size):
+    """Создание манифеста для Deployment"""
+    return {
+        'apiVersion': 'apps/v1',
+        'kind': 'Deployment',
+        'metadata': {
+            'name': f'mysql-{name}',
+            'namespace': namespace,
+            'labels': {
+                'app': 'mysql',
+                'instance': name,
+                'created-by': 'mysql-operator'
+            }
+        },
+        'spec': {
+            'replicas': 1,
+            'selector': {
+                'matchLabels': {
+                    'app': 'mysql',
+                    'instance': name
+                }
+            },
+            'template': {
+                'metadata': {
+                    'labels': {
+                        'app': 'mysql',
+                        'instance': name
+                    }
+                },
+                'spec': {
+                    'containers': [
+                        {
+                            'name': 'mysql',
+                            'image': image,
+                            'ports': [
+                                {
+                                    'containerPort': 3306,
+                                    'name': 'mysql'
+                                }
+                            ],
+                            'env': [
+                                {
+                                    'name': 'MYSQL_ROOT_PASSWORD',
+                                    'value': password
+                                },
+                                {
+                                    'name': 'MYSQL_DATABASE',
+                                    'value': database
+                                }
+                            ],
+                            'volumeMounts': [
+                                {
+                                    'name': 'mysql-storage',
+                                    'mountPath': '/var/lib/mysql'
+                                }
+                            ],
+                            'resources': {
+                                'requests': {
+                                    'memory': '256Mi',
+                                    'cpu': '100m'
+                                },
+                                'limits': {
+                                    'memory': '512Mi',
+                                    'cpu': '500m'
+                                }
+                            }
+                        }
+                    ],
+                    'volumes': [
+                        {
+                            'name': 'mysql-storage',
+                            'persistentVolumeClaim': {
+                                'claimName': f'mysql-{name}-pvc'
+                            }
+                        }
+                    ]
+                }
+            }
+        }
+    }
+
+def update_deployment_image(name, namespace, new_image, logger):
+    """Обновление образа в Deployment"""
+    apps_api = kubernetes.client.AppsV1Api()
+    
+    try:
+        deployment = apps_api.read_namespaced_deployment(
+            name=f"mysql-{name}",
+            namespace=namespace
+        )
+        
+        deployment.spec.template.spec.containers[0].image = new_image
+        
+        apps_api.patch_namespaced_deployment(
+            name=f"mysql-{name}",
+            namespace=namespace,
+            body=deployment
+        )
+        
+        logger.info(f"Образ MySQL обновлен на {new_image}")
+        
+    except ApiException as e:
+        logger.error(f"Ошибка при обновлении образа: {e}")
+        raise kopf.TemporaryError(f"Ошибка обновления образа: {e}", delay=30)

--- a/kubernetes-operators/sa.yaml
+++ b/kubernetes-operators/sa.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: mysql-operator
+  namespace: operators


### PR DESCRIPTION
# Выполнено ДЗ № 7

 - [x] Основное ДЗ
 - [x] Задание со *

## В процессе сделано:
 - Создан манифест объекта CustomResourceDeﬁnition со следующими параметрами:
    * объект уровня namespace
    * api group – otus.homework
    * kind – MySQL
    * plural name – mysqls
    * версия – v1
 - Объект имеет следующие обязательные атрибуты и правила их валидации (все поля строковые):
    * image – определяет docker-образ для создания
    * database – имя базы данных
    * password – пароль от БД
    * storage_size – размер хранилища под базу
 - Созданы манифесты ServiceAccount, ClusterRole и ClusterRoleBinding, описывающий сервис аккаунт с минимальным набором прав доступа к api серверу, необходимые для нашего CRD и чтобы функциональность не пострадала:
    * управление самим ресурсом CRD
    * создание и удаление ресурсов типа Service, PV, PVC
 - Создан манифест deployment для оператора, указав созданный ранее ServiceAccount и образ roﬂmaoinmysoul/mysql-operator:1.0.0
 - Создан манифест кастомного объекта kind: MySQL валидный для применения
 - При применении манифестов CRD создаётся, оператор работает и при создании кастомного ресурса типа MySQL создает Deployment с указанным образом mysql, service для него, PV и PVC, а при удалении объекта типа MySQL удаляются все созданные для него ресурсы
 - Создан свой оператор, который будет реализовывать следующий функционал:
    * при создании в кластере объектов с типом MySQL (mysqls.otus.homework/v1) будет создавать deployment с заданным образом mysql, сервис типа ClusterIP, PV и PVC заданного размера
    * при удалении объекта с типом MySQL будет удалять ранее созданные ресурсы

## Как запустить проект:
 - Создать виртуальную среду .kopf командой:
    python3 -m venv ~/.kopf
 - Активировать эту виртуальную среду:
    source ~/.kopf/bin/activate
 - Установить в эту среду пакеты kopf и kubernetes:
    pip3 install kopf kubernetes
 - Создать пространство имён:
    kubectl create ns operators
 - В директории SergSha_repo/kubernetes-operators запустить следующие команды:
    kubectl -f crd.yaml
    kopf run mysqloperator.py --verbose
 - В другом окне терминала в директории SergSha_repo/kubernetes-operators запустить команду:
    kubectl apply -f mysql.yaml

## Как проверить работоспособность:
 - Проверить, что создался CRD:
    kubectl get crds
 - Проверить, что создались необходимые ресурсы:
    kubectl get mysql -n operators
    kubectl get po,svc,deploy,pvc,pv -n operators
 - Удалить кастомный ресурс типа MySQL, для этого в директории SergSha_repo/kubernetes-operators выполнить команду:
     kubectl delete -f mysql.yaml
 - Проверить, что после удаления кастомного ресурса типа MySQL удалились все остальные ресурсы:
    kubectl get po,svc,deploy,mysql,pvc,pv -n operators    # No resources found

## PR checklist:
 - [ ] Выставлен label с темой домашнего задания
